### PR TITLE
HTML 1枚 のファイルサイズが大きくてパースに失敗する場合のエラー処理を追加

### DIFF
--- a/php/pathResolver.php
+++ b/php/pathResolver.php
@@ -53,7 +53,7 @@ class pathResolver{
 	 */
 	private function path_resolve_in_html( $src ){
 
-		// data-dec-blockブロックを削除
+		// HTMLをパース
 		$html = str_get_html(
 			$src ,
 			false, // $lowercase
@@ -63,6 +63,12 @@ class pathResolver{
 			DEFAULT_BR_TEXT, // $defaultBRText
 			DEFAULT_SPAN_TEXT // $defaultSpanText
 		);
+
+		if($html === false){
+			// HTMLパースに失敗した場合、無加工のまま返す。
+			$this->px->error('HTML Parse ERROR. $src size '.strlen($src).' byte(s) given; '.__FILE__.' ('.__LINE__.')');
+			return $src;
+		}
 
 		$conf_dom_selectors = array(
 			'*[href]'=>'href',

--- a/tests/mainTest.php
+++ b/tests/mainTest.php
@@ -882,6 +882,34 @@ class mainTest extends PHPUnit_Framework_TestCase{
 
 	}
 
+	/**
+	 * 大きすぎてパースできないHTMLを変換にかけるテスト
+	 */
+	public function testTooBigHtml(){
+		$this->fs->copy( __DIR__.'/testdata/standard/px-files/testconfs/config_exec.php', __DIR__.'/testdata/standard/px-files/config.php' );
+		$this->fs->save_file( __DIR__.'/testdata/standard/px-files/options.json', $this->testJson['pass_strip'] );
+		$output = $this->passthru( [
+			'php',
+			__DIR__.'/testdata/standard/.px_execute.php',
+			'-o', 'json',
+			'/broken.html'
+		] );
+		$output = json_decode($output);
+		// var_dump($output->errors);
+
+		$this->assertNotEmpty( $output->errors );
+
+		// 後始末
+		$output = $this->passthru( [
+			'php', __DIR__.'/testdata/standard/.px_execute.php', '/?PX=clearcache'
+		] );
+
+		clearstatcache();
+		$this->assertTrue( !is_dir( __DIR__.'/testdata/standard/caches/p/' ) );
+		$this->fs->save_file( __DIR__.'/testdata/standard/px-files/options.json', $this->testJson['relate'] );
+
+	}
+
 
 
 	/**

--- a/tests/testdata/standard/broken.html
+++ b/tests/testdata/standard/broken.html
@@ -1,0 +1,9 @@
+
+<?php for( $i = 1; $i < 30000; $i ++ ){ ?>
+<!--
+HTMLドキュメントのサイズが大きくなると、
+Simple HTML DOM Parser がパースに失敗する。
+-->
+<p><a href="this is a too BIG HTML file."></a></p>
+
+<?php } ?>


### PR DESCRIPTION
- $px->error() に報告を投げて、無加工のまま通すようにした。
